### PR TITLE
DEV: Use CSS custom properties for colors

### DIFF
--- a/assets/stylesheets/common/multilingual.scss
+++ b/assets/stylesheets/common/multilingual.scss
@@ -11,27 +11,6 @@ ol.category-breadcrumb li.content-language-discovery {
   margin: 0;
 }
 
-.edit-category-modal .field-item.category-name {
-  > span,
-  > label {
-    display: inline-block;
-  }
-
-  > span {
-    margin-left: 7px;
-  }
-
-  .d-icon {
-    width: 0.9em;
-    height: 0.9em;
-  }
-
-  input:disabled {
-    background-color: $primary-very-low;
-    color: rgba($primary, 0.7);
-  }
-}
-
 .topic-language-selector {
   margin-bottom: 9px;
   background-color: #f1f1f1;

--- a/assets/stylesheets/common/multilingual/admin.scss
+++ b/assets/stylesheets/common/multilingual/admin.scss
@@ -65,8 +65,8 @@
       text-align: center;
 
       &.disabled {
-        background-color: $primary-very-low;
-        color: $primary-low;
+        background-color: var(--primary-very-low);
+        color: var(--primary-low);
       }
     }
 

--- a/assets/stylesheets/common/multilingual/content-language-select-kit.scss
+++ b/assets/stylesheets/common/multilingual/content-language-select-kit.scss
@@ -8,7 +8,7 @@
 
   .select-kit-header .name,
   .select-kit-row .name {
-    color: $primary;
+    color: var(--primary);
   }
 }
 
@@ -18,10 +18,10 @@
     margin-left: 5px;
 
     &.has-languages {
-      background-color: $tertiary;
+      background-color: var(--tertiary);
 
       .d-icon {
-        color: $secondary;
+        color: var(--secondary);
       }
     }
   }
@@ -48,7 +48,7 @@
       cursor: pointer;
 
       &.active {
-        background: $tertiary-low;
+        background: var(--tertiary-low);
       }
     }
   }

--- a/assets/stylesheets/common/multilingual/language-switcher.scss
+++ b/assets/stylesheets/common/multilingual/language-switcher.scss
@@ -3,7 +3,7 @@
   padding: 5px 10px;
   font-size: 1.1em;
   text-decoration: none;
-  color: $primary;
+  color: var(--primary);
   cursor: pointer;
 
   &:last-of-type {
@@ -11,11 +11,11 @@
   }
 
   &:hover {
-    background-color: $tertiary-low !important;
+    background-color: var(--tertiary-low) !important;
   }
 
   &.current {
-    background-color: $tertiary-low;
+    background-color: var(--tertiary-low);
   }
 }
 
@@ -28,26 +28,26 @@
 
 .language-switcher-bar {
   position: relative;
-  background-color: $secondary;
-  border: 1px solid rgba($primary, 0.1);
+  background-color: var(--secondary);
+  border: 1px solid rgba(var(--primary-rgb), 0.1);
   border-radius: 2px;
   box-shadow: shadow("dropdown");
   padding: 10px;
   display: flex;
 
   button.btn {
-    background-color: $secondary;
+    background-color: var(--secondary);
 
     .d-icon {
-      color: $primary;
+      color: var(--primary);
     }
 
     &:hover,
     &.btn-hover:hover {
-      background-color: $secondary;
+      background-color: var(--secondary);
 
       .d-icon {
-        color: $primary;
+        color: var(--primary);
       }
     }
   }
@@ -57,8 +57,8 @@
     overflow: scroll;
     max-height: 400px;
     width: 400px;
-    background-color: $secondary;
-    border: 1px solid $primary-low;
+    background-color: var(--secondary);
+    border: 1px solid var(--primary-low);
     box-shadow: shadow("dropdown");
     bottom: 60px;
     padding: 10px 14px;

--- a/assets/stylesheets/mobile/multilingual.scss
+++ b/assets/stylesheets/mobile/multilingual.scss
@@ -21,10 +21,10 @@
 
 .language-switcher-bar {
   width: 100%;
-  border-top: 1px solid $primary-low;
+  border-top: 1px solid var(--primary-low);
   box-sizing: border-box;
   box-shadow: 0px 1px 10px rgba(0, 0, 0, 0.15);
-  background-color: $secondary;
+  background-color: var(--secondary);
   position: fixed;
   bottom: 0;
   left: 0;


### PR DESCRIPTION
Switches all SCSS color variables to CSS custom properties. This is to future-proof the plugin to changes in how plugin stylesheets are going to be compiled in core (plus it has better support for automatic dark mode).

Also cleans up styling that no longer applies in core, there is no longer an `.edit-category-modal` element. 