### PR TITLE
FIX: Translations for table header

### DIFF
--- a/assets/javascripts/discourse/templates/admin-multilingual-translations.hbs
+++ b/assets/javascripts/discourse/templates/admin-multilingual-translations.hbs
@@ -13,8 +13,8 @@
   {{#if translations}}
     <table class="table translations-list grid">
       <thead>
-        {{table-header-toggle field="code" labelKey="multilingual.code"}}
-        {{table-header-toggle field="type" labelKey="multilingual.translations.type"}}
+        {{table-header-toggle field="code" labelKey="multilingual.code" automatic=true}}
+        {{table-header-toggle field="type" labelKey="multilingual.translations.type" automatic=true}}
         <th>Actions</th>
       </thead>
       <tbody>

--- a/assets/javascripts/discourse/templates/components/admin-language-list.hbs
+++ b/assets/javascripts/discourse/templates/components/admin-language-list.hbs
@@ -1,10 +1,10 @@
 <table class="table languages-list grid">
   <thead>
-    {{table-header-toggle field="code" labelKey="multilingual.code" order=order asc=ascending}}
-    {{table-header-toggle field="name" labelKey="multilingual.languages.name" order=order asc=ascending}}
-    {{table-header-toggle field="nativeName" labelKey="multilingual.languages.native_name" order=order asc=ascending}}
-    {{table-header-toggle field="content_enabled" labelKey="multilingual.languages.content" order=order asc=ascending classNames=controlColumnClassNames toggleAll=allContentEnabled}}
-    {{table-header-toggle field="interface_enabled" labelKey="multilingual.languages.interface" order=order asc=ascending classNames=controlColumnClassNames toggleAll=allInterfaceEnabled}}
+    {{table-header-toggle field="code" labelKey="multilingual.code" order=order asc=ascending automatic=true}}
+    {{table-header-toggle field="name" labelKey="multilingual.languages.name" order=order asc=ascending automatic=true}}
+    {{table-header-toggle field="nativeName" labelKey="multilingual.languages.native_name" order=order asc=ascending automatic=true}}
+    {{table-header-toggle field="content_enabled" labelKey="multilingual.languages.content" order=order asc=ascending classNames=controlColumnClassNames toggleAll=allContentEnabled automatic=true}}
+    {{table-header-toggle field="interface_enabled" labelKey="multilingual.languages.interface" order=order asc=ascending classNames=controlColumnClassNames toggleAll=allInterfaceEnabled automatic=true}}
     <th class="language-control">Actions</th>
   </thead>
   <tbody>


### PR DESCRIPTION
Due to some recent core changes to the `table-header-toggle` component, `translated=` needs to be passed in.