### PR TITLE
FIX: replace deprecated $.cookie with cookie module

### DIFF
--- a/assets/javascripts/discourse/lib/multilingual-route.js.es6
+++ b/assets/javascripts/discourse/lib/multilingual-route.js.es6
@@ -1,6 +1,7 @@
 import { getOwner } from "discourse-common/lib/get-owner";
 import { next } from "@ember/runloop";
 import DiscourseURL from "discourse/lib/url";
+import cookie from "discourse/lib/cookie";
 
 const contentLanguageParam = "content_languages";
 const localeParam = "locale";
@@ -67,7 +68,7 @@ function replaceState(path) {
 
 function addParam(paramName, value, opts = {}) {
   if (opts.add_cookie) {
-    $.cookie(`discourse_${paramName}`, value);
+    cookie(`discourse_${paramName}`, value);
   }
 
   if (useDiscoveryController(opts.ctx, paramName)) {


### PR DESCRIPTION
When switching guest locale, this warning will show in console.

> Deprecation notice: $.cookie is being removed from Discourse. Please import our cookie module and use that instead. (deprecated since Discourse 2.6.0) (removal in Discourse 2.7.0)