### PR TITLE
fix typo in client.es.yml and server.es.yml

### DIFF
--- a/config/locales/client.es.yml
+++ b/config/locales/client.es.yml
@@ -1,4 +1,4 @@
-en:
+es:
   js:  
     tagging:
       groups:

--- a/config/locales/server.es.yml
+++ b/config/locales/server.es.yml
@@ -1,4 +1,4 @@
-en:
+es:
   site_settings:
     multilingual_enabled: Plug-in multilingüe habilitado.
     multilingual_content_languages_enabled: Idiomas del contenido habilitados.


### PR DESCRIPTION
Fix typo (missing "es" top level key)