### PR TITLE
FIX: Tag caching fixes

### DIFF
--- a/app/models/multilingual/custom_translation.rb
+++ b/app/models/multilingual/custom_translation.rb
@@ -31,6 +31,7 @@ class Multilingual::CustomTranslation < ActiveRecord::Base
 
   def after_save
     add_locale
+    Discourse.cache.delete("discourse-multilingual_translation_#{self.file_type}")
     Multilingual::Cache.refresh_clients([self.locale])
   end
 
@@ -45,6 +46,7 @@ class Multilingual::CustomTranslation < ActiveRecord::Base
 
   def after_remove
     self.destroy!
+    Discourse.cache.delete("discourse-multilingual_translation_#{self.file_type}")
     Multilingual::Cache.refresh_clients([self.locale])
   end
 

--- a/app/models/multilingual/custom_translation.rb
+++ b/app/models/multilingual/custom_translation.rb
@@ -30,8 +30,8 @@ class Multilingual::CustomTranslation < ActiveRecord::Base
   end
 
   def after_save
-    Discourse.cache.clear
     add_locale
+    Multilingual::Cache.refresh_clients([self.locale])
   end
 
   def remove
@@ -45,7 +45,7 @@ class Multilingual::CustomTranslation < ActiveRecord::Base
 
   def after_remove
     self.destroy!
-    Discourse.cache.clear
+    Multilingual::Cache.refresh_clients([self.locale])
   end
 
   def process(translations)

--- a/assets/javascripts/discourse/components/multilingual-uploader.js.es6
+++ b/assets/javascripts/discourse/components/multilingual-uploader.js.es6
@@ -9,6 +9,7 @@ export default Component.extend(UppyUploadMixin, {
   type: "yml",
   addDisabled: alias("uploading"),
   elementId: "multilingual-uploader",
+  preventDirectS3Uploads: true,
   classNameBindings: [":multilingual-uploader", "uploadType"],
   locale: null,
   message: null,

--- a/extensions/extra_locales_controller.rb
+++ b/extensions/extra_locales_controller.rb
@@ -22,20 +22,10 @@ module ExtraLocalesControllerMultilingualClassExtension
   end
 
   def bundle_js_hash(bundle)
-    if bundle == OVERRIDES_BUNDLE
-      site = RailsMultisite::ConnectionManagement.current_db
-
-      @by_site ||= {}
-      @by_site[site] ||= {}
-      @by_site[site][I18n.locale] ||= begin
-        js = bundle_js(bundle)
-        js.present? ? Digest::MD5.hexdigest(js) : nil
-      end
-    elsif bundle == "tags"
+    if bundle == "tags"
       Digest::MD5.hexdigest(bundle_js(bundle))
     else
-      @bundle_js_hash ||= {}
-      @bundle_js_hash["#{bundle}_#{I18n.locale}"] ||= Digest::MD5.hexdigest(bundle_js(bundle))
+      super(bundle)
     end
   end
 end

--- a/plugin.rb
+++ b/plugin.rb
@@ -166,7 +166,7 @@ after_initialize do
 
   add_class_method(:js_locale_helper, :output_locale_tags) do |locale_str|
     <<~JS
-      I18n.tag_translations = #{Multilingual::Translation.get("tag").to_json};
+      I18n.tag_translations = #{Multilingual::Translation.get("tag").slice(locale_str.to_sym).to_json};
     JS
   end
 


### PR DESCRIPTION
* FIX: tags translations not refreshing when data is updated - this is now seamless with a targetted refresh of clients using that specific locale
* FIX: add Uppy option in attempt to get uploads working on Official Hosted instance based on this comment: [discourse/app/assets/javascripts/discourse/app/mixins/uppy-upload.js at 0760b249ffe39a9ff57b7e36b6304e63a5082d7e · discourse/discourse (github.com)](https://github.com/discourse/discourse/blame/0760b249ffe39a9ff57b7e36b6304e63a5082d7e/app/assets/javascripts/discourse/app/mixins/uppy-upload.js#L273)
* IMPROVE: limit injected js tag data to current locale
* IMPROVE: refresh clients using same locale as translation file change
* IMPROVE: delete specific translation type cache on add or remove file