### PR TITLE
FIX: prevent nil class error when launching site

### DIFF
--- a/lib/multilingual/translation.rb
+++ b/lib/multilingual/translation.rb
@@ -23,7 +23,7 @@ class Multilingual::Translation
     if is_custom(type)
       data = get_custom(type)
 
-      return nil if data == {}
+      return {} if data == {}
 
       result = {}
       data.each do |d|

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # name: discourse-multilingual
 # about: Features to support multilingual forums
-# version: 0.2.3
+# version: 0.2.4
 # url: https://github.com/paviliondev/discourse-multilingual
 # authors: Angus McLeod, Robert Barrow
 

--- a/spec/components/translation_spec.rb
+++ b/spec/components/translation_spec.rb
@@ -52,7 +52,11 @@ describe Multilingual::Translation do
     expect(Multilingual::Translation.get("category_description", ["knowledge"])).to eq({ wbp: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Neque aliquam vestibulum morbi blandit. Libero id faucibus nisl tincidunt eget nullam non nisi. Ac odio tempor orci dapibus ultrices in. Vitae justo eget magna fermentum iaculis eu non." })
   end
 
-  it "tags  are available as a translation" do
+  it "when there are no uploaded tag translations, return empty hash" do
+    expect(Multilingual::Translation.get("tag")).to eq({})
+  end
+
+  it "tags are available as a translation" do
     Multilingual::CustomTranslation.create(
       file_name: "tag.wbp.yml",
       file_type: "tag",

--- a/spec/serializers/site_serializer_spec.rb
+++ b/spec/serializers/site_serializer_spec.rb
@@ -86,7 +86,7 @@ describe SiteSerializer do
       serialized = described_class.new(Site.new(guardian), scope: guardian, root: false).as_json
       c1 = serialized[:categories].find { |c| c[:id] == category.id }
 
-      expect(c1[:name]).to eq("Amazing Category 0")
+      expect(c1[:name]).to eq(category.name)
     end
   end
 end


### PR DESCRIPTION
* includes fixes to one test and additional test to cover part of the error condition that occurs that can easily be tested in a unit test.