### PR TITLE
DEV: Resolve deprecations in plugin.rb

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -249,10 +249,6 @@ after_initialize do
     end
   end
 
-  add_to_serializer(:basic_category, :include_name_translations?) { name_translations.present? }
-
-  add_to_serializer(:basic_category, :include_description_translations?) { description_translations.present? }
-
   add_to_serializer(:tag_group, :content_language_group) do
     content_language_group_enabled || content_language_group_disabled
   end

--- a/plugin.rb
+++ b/plugin.rb
@@ -197,11 +197,11 @@ after_initialize do
     end
   end
 
-  add_to_serializer(:basic_category, :slug_path, false) do
+  add_to_serializer(:basic_category, :slug_path, respect_plugin_enabled: false) do
     object.slug_path
   end
 
-  add_to_serializer(:basic_category, :name, false) do
+  add_to_serializer(:basic_category, :name, respect_plugin_enabled: false) do
     if object.uncategorized?
       I18n.t('uncategorized_category_name', locale: SiteSetting.default_locale)
     elsif !(scope && scope.current_user && scope.current_user.locale && object.slug_path && Multilingual::Translation.get("category_name", object.slug_path)).blank?
@@ -211,7 +211,7 @@ after_initialize do
     end
   end
 
-  add_to_serializer(:basic_category, :description_text, false) do
+  add_to_serializer(:basic_category, :description_text, respect_plugin_enabled: false) do
     if object.uncategorized?
       I18n.t('category.uncategorized_description', locale: SiteSetting.default_locale)
     elsif !(scope && scope.current_user && scope.current_user.locale && object.slug_path && Multilingual::Translation.get("category_description", object.slug_path)).blank?
@@ -221,7 +221,7 @@ after_initialize do
     end
   end
 
-  add_to_serializer(:basic_category, :description, false) do
+  add_to_serializer(:basic_category, :description, respect_plugin_enabled: false) do
     if object.uncategorized?
       I18n.t('category.uncategorized_description', locale: SiteSetting.default_locale)
     elsif !(scope && scope.current_user && scope.current_user.locale && object.slug_path && Multilingual::Translation.get("category_description", object.slug_path)).blank?
@@ -231,7 +231,7 @@ after_initialize do
     end
   end
 
-  add_to_serializer(:basic_category, :description_excerpt, false) do
+  add_to_serializer(:basic_category, :description_excerpt, respect_plugin_enabled: false) do
     if object.uncategorized?
       I18n.t('category.uncategorized_description', locale: SiteSetting.default_locale)
     elsif !(scope && scope.current_user && scope.current_user.locale && object.slug_path && Multilingual::Translation.get("category_description", object.slug_path)).blank?
@@ -241,7 +241,7 @@ after_initialize do
     end
   end
 
-  add_to_serializer(:site, :categories, false) do
+  add_to_serializer(:site, :categories, respect_plugin_enabled: false) do
     object.categories.map do |c|
       if c[:slug] == "uncategorized"
         c[:name] = I18n.t('uncategorized_category_name', locale: SiteSetting.default_locale)

--- a/plugin.rb
+++ b/plugin.rb
@@ -178,13 +178,10 @@ after_initialize do
     ActiveModel::ArraySerializer.new(languages, each_serializer: Multilingual::BasicLanguageSerializer, root: false).as_json
   end
 
-  add_to_serializer(:site, :content_languages) { serialize_languages(object.content_languages) }
-  add_to_serializer(:site, :include_content_languages?) { Multilingual::ContentLanguage.enabled }
+  add_to_serializer(:site, :content_languages, include_condition: -> { Multilingual::ContentLanguage.enabled }) { serialize_languages(object.content_languages) }
   add_to_serializer(:site, :interface_languages) { serialize_languages(object.interface_languages) }
-  add_to_serializer(:topic_view, :content_language_tags) { Multilingual::ContentTag.filter(topic.tags).map(&:name) }
-  add_to_serializer(:topic_view, :include_content_language_tags?) { Multilingual::ContentLanguage.enabled }
-  add_to_serializer(:topic_list_item, :content_language_tags) { Multilingual::ContentTag.filter(topic.tags).map(&:name) }
-  add_to_serializer(:topic_list_item, :include_content_language_tags?) { Multilingual::ContentLanguage.enabled }
+  add_to_serializer(:topic_view, :content_language_tags, include_condition: -> { Multilingual::ContentLanguage.enabled }) { Multilingual::ContentTag.filter(topic.tags).map(&:name) }
+  add_to_serializer(:topic_list_item, :content_language_tags, include_condition: -> { Multilingual::ContentLanguage.enabled }) { Multilingual::ContentTag.filter(topic.tags).map(&:name) }
 
   add_to_serializer(:current_user, :content_languages) do
     if user_content_languages = object.content_languages

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # name: discourse-multilingual
 # about: Features to support multilingual forums
-# version: 0.2.9
+# version: 0.2.10
 # url: https://github.com/paviliondev/discourse-multilingual
 # authors: Angus McLeod, Robert Barrow
 # contact_emails: development@pavilion.tech


### PR DESCRIPTION
This resolves the deprecations in `plugin.rb`.

Note: It removes two unused `include_` serializers. I believe they have been left out since this commit: [fa7c15618286555bccf254858d65172c10b692bf](https://github.com/paviliondev/discourse-multilingual/commit/fa7c15618286555bccf254858d65172c10b692bf#diff-040b0c3e0e3b0c377ccb9da72d51e1a9716135b8958e74aa81f104651972ee23).
`name_translations` and `description_translations` have been renamed/refactored, and the `include_` ones have been kept.


