### PR TITLE
DEV: Resolve `link-to.positional-arguments` deprecation

### DIFF
--- a/assets/javascripts/discourse/templates/components/admin-language.hbs
+++ b/assets/javascripts/discourse/templates/components/admin-language.hbs
@@ -13,7 +13,7 @@
 <td class={{contentClass}}>
   {{#if contentDisabled}}
     {{#if language.content_tag_conflict}}
-      {{#link-to "tag.show" language.locale}}
+      {{#link-to route="tag.show" model=language.locale}}
         {{d-icon "warning"}}
         <span>{{i18n "multilingual.languages.content_tag_conflict" tagName=language.locale}}</span>
       {{/link-to}}


### PR DESCRIPTION
https://deprecations.emberjs.com/v3.x#toc_ember-glimmer-link-to-positional-arguments

This deprecation happens at build-time, which means it doesn't get surfaced like other deprecations in Discourse themes/plugins.