### PR TITLE
FIX  : Custom Translations not showing to logged off users

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -26,41 +26,41 @@ end
 end
 
 after_initialize do
-  %w[
-    ../lib/multilingual/multilingual.rb
-    ../lib/multilingual/cache.rb
-    ../lib/multilingual/language/content_tag.rb
-    ../lib/multilingual/language/exclusion.rb
-    ../lib/multilingual/language/custom.rb
-    ../lib/multilingual/language/content.rb
-    ../lib/multilingual/language/interface.rb
-    ../lib/multilingual/language.rb
-    ../lib/multilingual/translation/locale.rb
-    ../lib/multilingual/translation.rb
-    ../lib/multilingual/translator.rb
-    ../lib/multilingual/locale_loader.rb
-    ../jobs/update_content_language_tags.rb
-    ../config/routes.rb
-    ../app/models/multilingual/custom_translation.rb
-    ../app/serializers/multilingual/basic_language_serializer.rb
-    ../app/serializers/multilingual/language_serializer.rb
-    ../app/serializers/multilingual/custom_translation_serializer.rb
-    ../app/controllers/multilingual/admin_controller.rb
-    ../app/controllers/multilingual/admin_languages_controller.rb
-    ../app/controllers/multilingual/admin_translations_controller.rb
-    ../extensions/category_list.rb
-    ../extensions/discourse_tagging.rb
-    ../extensions/extra_locales_controller.rb
-    ../extensions/i18n.rb
-    ../extensions/js_locale_helper.rb
-    ../extensions/post.rb
-    ../extensions/tag_group.rb
-    ../extensions/topic_serializer.rb
-    ../extensions/application_controller.rb
-    ../extensions/tag.rb
-  ].each do |path|
-    load File.expand_path(path, __FILE__)
-  end
+    %w[
+      ../lib/multilingual/multilingual.rb
+      ../lib/multilingual/cache.rb
+      ../lib/multilingual/language/content_tag.rb
+      ../lib/multilingual/language/exclusion.rb
+      ../lib/multilingual/language/custom.rb
+      ../lib/multilingual/language/content.rb
+      ../lib/multilingual/language/interface.rb
+      ../lib/multilingual/language.rb
+      ../lib/multilingual/translation/locale.rb
+      ../lib/multilingual/translation.rb
+      ../lib/multilingual/translator.rb
+      ../lib/multilingual/locale_loader.rb
+      ../jobs/update_content_language_tags.rb
+      ../config/routes.rb
+      ../app/models/multilingual/custom_translation.rb
+      ../app/serializers/multilingual/basic_language_serializer.rb
+      ../app/serializers/multilingual/language_serializer.rb
+      ../app/serializers/multilingual/custom_translation_serializer.rb
+      ../app/controllers/multilingual/admin_controller.rb
+      ../app/controllers/multilingual/admin_languages_controller.rb
+      ../app/controllers/multilingual/admin_translations_controller.rb
+      ../extensions/category_list.rb
+      ../extensions/discourse_tagging.rb
+      ../extensions/extra_locales_controller.rb
+      ../extensions/i18n.rb
+      ../extensions/js_locale_helper.rb
+      ../extensions/post.rb
+      ../extensions/tag_group.rb
+      ../extensions/topic_serializer.rb
+      ../extensions/application_controller.rb
+      ../extensions/tag.rb
+    ].each do |path|
+      load File.expand_path(path, __FILE__)
+    end
 
   Multilingual.setup if SiteSetting.multilingual_enabled
 
@@ -92,251 +92,266 @@ after_initialize do
   add_to_class(:site, :interface_languages) { Multilingual::InterfaceLanguage.list }
   add_to_class(:site, :content_languages) { Multilingual::ContentLanguage.list }
 
-  add_to_class(:user, :effective_locale) do
-    if SiteSetting.allow_user_locale &&
-       self.locale.present? &&
-       Multilingual::InterfaceLanguage.enabled?(self.locale)
-      self.locale
-    else
-      SiteSetting.default_locale
+    add_to_class(:user, :effective_locale) do
+      if SiteSetting.allow_user_locale &&
+        self.locale.present? &&
+        Multilingual::InterfaceLanguage.enabled?(self.locale)
+        self.locale
+      else
+        SiteSetting.default_locale
+      end
     end
-  end
 
-  add_to_class(:user, :content_languages) do
-    content_languages = self.custom_fields['content_languages'] || []
-    [*content_languages].select { |l| Multilingual::ContentLanguage.enabled?(l) }
-  end
-
-  add_to_class(:topic, :content_languages) do
-    if custom_fields['content_languages']
-      [*custom_fields['content_languages']]
-    else
-      []
+    add_to_class(:user, :content_languages) do
+      content_languages = self.custom_fields['content_languages'] || []
+      [*content_languages].select { |l| Multilingual::ContentLanguage.enabled?(l) }
     end
-  end
 
-  add_to_class(:guardian, :topic_requires_language_tag?) do |topic|
-    !topic.private_message? &&
-    Multilingual::ContentLanguage.enabled &&
-    (SiteSetting.multilingual_require_content_language_tag === 'yes' ||
-    (!is_staff? && SiteSetting.multilingual_require_content_language_tag === 'non-staff'))
-  end
+    add_to_class(:topic, :content_languages) do
+      if custom_fields['content_languages']
+        [*custom_fields['content_languages']]
+      else
+        []
+      end
+    end
 
-  add_to_class(:tag_groups_controller, :destroy_content_tags) do
-    guardian.is_admin?
-    Multilingual::ContentTag.destroy_all
-    render json: success_json
-  end
+    add_to_class(:guardian, :topic_requires_language_tag?) do |topic|
+      !topic.private_message? &&
+        Multilingual::ContentLanguage.enabled &&
+        (SiteSetting.multilingual_require_content_language_tag === 'yes' ||
+          (!is_staff? && SiteSetting.multilingual_require_content_language_tag === 'non-staff'))
+    end
 
-  add_to_class(:tag_groups_controller, :update_content_tags) do
-    guardian.is_admin?
-    Multilingual::ContentTag.update_all
-    render json: success_json
-  end
+    add_to_class(:tag_groups_controller, :destroy_content_tags) do
+      guardian.is_admin?
+      Multilingual::ContentTag.destroy_all
+      render json: success_json
+    end
 
-  add_class_method(:discourse_tagging, :validate_require_language_tag) do |guardian, topic, tag_names|
-    if guardian.topic_requires_language_tag?(topic) && (tag_names.blank? ||
-       !Tag.where(name: tag_names).where("id IN (
+    add_to_class(:tag_groups_controller, :update_content_tags) do
+      guardian.is_admin?
+      Multilingual::ContentTag.update_all
+      render json: success_json
+    end
+
+    add_class_method(:discourse_tagging, :validate_require_language_tag) do |guardian, topic, tag_names|
+      if guardian.topic_requires_language_tag?(topic) && (tag_names.blank? ||
+        !Tag.where(name: tag_names).where("id IN (
           #{DiscourseTagging::TAG_GROUP_TAG_IDS_SQL}
           AND tg.name = '#{Multilingual::ContentTag::GROUP}'
         )").exists?)
 
-      topic.errors.add(:base, I18n.t("multilingual.content_language_tag_required"))
+        topic.errors.add(:base, I18n.t("multilingual.content_language_tag_required"))
 
-      false
-    else
-      true
-    end
-  end
-
-  add_class_method(:locale_site_setting, :valid_value?) { |val| Multilingual::InterfaceLanguage.supported?(val) }
-
-  add_class_method(:locale_site_setting, :values) do
-    @values ||= supported_locales.reduce([]) do |result, locale|
-      if Multilingual::InterfaceLanguage.enabled?(locale)
-        lang = Multilingual::Language.all[locale] || Multilingual::Language.all[locale.split("_")[0]]
-        result.push(
-          name: lang ? lang['nativeName'] : locale,
-          value: locale
-        )
+        false
+      else
+        true
       end
-      result
     end
-  end
 
-  add_class_method(:js_locale_helper, :output_locale_tags) do |locale_str|
-    <<~JS
+    add_class_method(:locale_site_setting, :valid_value?) { |val| Multilingual::InterfaceLanguage.supported?(val) }
+
+    add_class_method(:locale_site_setting, :values) do
+      @values ||= supported_locales.reduce([]) do |result, locale|
+        if Multilingual::InterfaceLanguage.enabled?(locale)
+          lang = Multilingual::Language.all[locale] || Multilingual::Language.all[locale.split("_")[0]]
+          result.push(
+            name: lang ? lang['nativeName'] : locale,
+            value: locale
+          )
+        end
+        result
+      end
+    end
+
+    add_class_method(:js_locale_helper, :output_locale_tags) do |locale_str|
+      <<~JS
       I18n.tag_translations = #{Multilingual::Translation.get("tag").slice(locale_str.to_sym).to_json};
     JS
-  end
+    end
 
-  add_to_serializer(:user, :locale) do
-    Multilingual::InterfaceLanguage.enabled?(object.locale) ? object.locale : nil
-  end
+    add_to_serializer(:user, :locale) do
+      Multilingual::InterfaceLanguage.enabled?(object.locale) ? object.locale : nil
+    end
 
-  add_to_serializer(:site, :serialize_languages) do |languages = []|
-    ActiveModel::ArraySerializer.new(languages, each_serializer: Multilingual::BasicLanguageSerializer, root: false).as_json
-  end
+    add_to_serializer(:site, :serialize_languages) do |languages = []|
+      ActiveModel::ArraySerializer.new(languages, each_serializer: Multilingual::BasicLanguageSerializer, root: false).as_json
+    end
 
-  add_to_serializer(:site, :content_languages) { serialize_languages(object.content_languages) }
-  add_to_serializer(:site, :include_content_languages?) { Multilingual::ContentLanguage.enabled }
-  add_to_serializer(:site, :interface_languages) { serialize_languages(object.interface_languages) }
-  add_to_serializer(:topic_view, :content_language_tags) { Multilingual::ContentTag.filter(topic.tags).map(&:name) }
-  add_to_serializer(:topic_view, :include_content_language_tags?) { Multilingual::ContentLanguage.enabled }
-  add_to_serializer(:topic_list_item, :content_language_tags) { Multilingual::ContentTag.filter(topic.tags).map(&:name) }
-  add_to_serializer(:topic_list_item, :include_content_language_tags?) { Multilingual::ContentLanguage.enabled }
+    add_to_serializer(:site, :content_languages) { serialize_languages(object.content_languages) }
+    add_to_serializer(:site, :include_content_languages?) { Multilingual::ContentLanguage.enabled }
+    add_to_serializer(:site, :interface_languages) { serialize_languages(object.interface_languages) }
+    add_to_serializer(:topic_view, :content_language_tags) { Multilingual::ContentTag.filter(topic.tags).map(&:name) }
+    add_to_serializer(:topic_view, :include_content_language_tags?) { Multilingual::ContentLanguage.enabled }
+    add_to_serializer(:topic_list_item, :content_language_tags) { Multilingual::ContentTag.filter(topic.tags).map(&:name) }
+    add_to_serializer(:topic_list_item, :include_content_language_tags?) { Multilingual::ContentLanguage.enabled }
 
-  add_to_serializer(:current_user, :content_languages) do
-    if user_content_languages = object.content_languages
-      user_content_languages.map do |locale|
-        Multilingual::BasicLanguageSerializer.new(
-          Multilingual::Language.get(locale).first,
-          root: false
-        )
+    add_to_serializer(:current_user, :content_languages) do
+      if user_content_languages = object.content_languages
+        user_content_languages.map do |locale|
+          Multilingual::BasicLanguageSerializer.new(
+            Multilingual::Language.get(locale).first,
+            root: false
+          )
+        end
       end
     end
-  end
 
-  add_to_serializer(:basic_category, :slug_path, false) do
-    object.slug_path
-  end
-
-  add_to_serializer(:basic_category, :name, false) do
-    if object.uncategorized?
-      I18n.t('uncategorized_category_name', locale: SiteSetting.default_locale)
-    elsif !(scope && scope.current_user && scope.current_user.locale && object.slug_path && Multilingual::Translation.get("category_name", object.slug_path)).blank?
-      Multilingual::Translation.get("category_name", object.slug_path)[scope.current_user.locale.to_sym] || object.name
-    else
-      object.name
+    add_to_serializer(:basic_category, :slug_path, false) do
+      object.slug_path
     end
-  end
 
-  add_to_serializer(:basic_category, :description_text, false) do
-    if object.uncategorized?
-      I18n.t('category.uncategorized_description', locale: SiteSetting.default_locale)
-    elsif !(scope && scope.current_user && scope.current_user.locale && object.slug_path && Multilingual::Translation.get("category_description", object.slug_path)).blank?
-      Multilingual::Translation.get("category_description", object.slug_path)[scope.current_user.locale.to_sym] || object.description_text
-    else
-      object.description_text
-    end
-  end
+    add_to_serializer(:basic_category, :name, false) do
+      if object.uncategorized?
+        puts "uncagecorized case"
+        I18n.t('uncategorized_category_name', locale: I18n.locale)
+      elsif !(object.slug_path && Multilingual::Translation.get("category_name", object.slug_path)).blank?
+        if (scope && scope.current_user && scope.current_user.locale)
+          tmp_locale = scope.current_user.locale
+        else
+          tmp_locale = I18n.locale
+        end
+        puts "tmp_locale = ", tmp_locale
+        puts "object.name = " + object.name
 
-  add_to_serializer(:basic_category, :description, false) do
-    if object.uncategorized?
-      I18n.t('category.uncategorized_description', locale: SiteSetting.default_locale)
-    elsif !(scope && scope.current_user && scope.current_user.locale && object.slug_path && Multilingual::Translation.get("category_description", object.slug_path)).blank?
-      Multilingual::Translation.get("category_description", object.slug_path)[scope.current_user.locale.to_sym] || object.description
-    else
-      object.description
-    end
-  end
-
-  add_to_serializer(:basic_category, :description_excerpt, false) do
-    if object.uncategorized?
-      I18n.t('category.uncategorized_description', locale: SiteSetting.default_locale)
-    elsif !(scope && scope.current_user && scope.current_user.locale && object.slug_path && Multilingual::Translation.get("category_description", object.slug_path)).blank?
-      Multilingual::Translation.get("category_description", object.slug_path)[scope.current_user.locale.to_sym] || object.description_excerpt
-    else
-      object.description_excerpt
-    end
-  end
-
-  add_to_serializer(:site, :categories, false) do
-    object.categories.map do |c|
-      if c[:slug] == "uncategorized"
-        c[:name] = I18n.t('uncategorized_category_name', locale: SiteSetting.default_locale)
-      elsif SiteSetting.multilingual_enabled && !(scope && scope.current_user && scope.current_user.locale && c[:slug_path] && Multilingual::Translation.get("category_name", c[:slug_path])).blank?
-        c[:name] = Multilingual::Translation.get("category_name", c[:slug_path])[scope.current_user.locale.to_sym] || c[:name]
+        Multilingual::Translation.get("category_name", object.slug_path)[tmp_locale.to_sym] || object.name
+      else
+        object.name
       end
-      c.to_h
     end
-  end
 
-  add_to_serializer(:basic_category, :include_name_translations?) { name_translations.present? }
-
-  add_to_serializer(:basic_category, :include_description_translations?) { description_translations.present? }
-
-  add_to_serializer(:tag_group, :content_language_group) do
-    content_language_group_enabled || content_language_group_disabled
-  end
-
-  add_to_serializer(:tag_group, :content_language_group_enabled) do
-    object.id == Multilingual::ContentTag.enabled_group.id
-  end
-
-  add_to_serializer(:tag_group, :content_language_group_disabled) do
-    object.id == Multilingual::ContentTag.disabled_group.id
-  end
-
-  add_to_serializer(:tag_group, :name) do
-    content_language_group ?
-    I18n.t("multilingual.content_tag_group_name#{content_language_group_disabled ? "_disabled" : ""}") :
-    object.name
-  end
-
-  ## This is necessary due to the workaround for jquery ajax added in multilingual-initializer
-  on(:user_updated) do |user|
-    if Multilingual::ContentLanguage.enabled && user.custom_fields['content_languages'].blank?
-      user.custom_fields['content_languages'] = []
-      user.save_custom_fields(true)
+    add_to_serializer(:basic_category, :description_text, false) do
+      if object.uncategorized?
+        I18n.t('category.uncategorized_description', locale: SiteSetting.default_locale)
+      elsif !(scope && scope.current_user && scope.current_user.locale && object.slug_path && Multilingual::Translation.get("category_description", object.slug_path)).blank?
+        Multilingual::Translation.get("category_description", object.slug_path)[scope.current_user.locale.to_sym] || object.description_text
+      else
+        object.description_text
+      end
     end
-  end
 
-  on(:site_setting_changed) do |setting, old_val, new_val|
-    if setting.to_sym == :multilingual_content_languages_enabled &&
-       ActiveModel::Type::Boolean.new.cast(new_val)
-      Multilingual::ContentTag.enqueue_update_all
+    add_to_serializer(:basic_category, :description, false) do
+      if object.uncategorized?
+        I18n.t('category.uncategorized_description', locale: SiteSetting.default_locale)
+      elsif !(scope && scope.current_user && scope.current_user.locale && object.slug_path && Multilingual::Translation.get("category_description", object.slug_path)).blank?
+        Multilingual::Translation.get("category_description", object.slug_path)[scope.current_user.locale.to_sym] || object.description
+      else
+        object.description
+      end
     end
-  end
 
-  on(:before_create_topic) do |topic, creator|
-    if Multilingual::ContentLanguage.enabled
-      content_language_tags = [*creator.opts[:content_language_tags]]
+    add_to_serializer(:basic_category, :description_excerpt, false) do
+      if object.uncategorized?
+        I18n.t('category.uncategorized_description', locale: SiteSetting.default_locale)
+      elsif !(scope && scope.current_user && scope.current_user.locale && object.slug_path && Multilingual::Translation.get("category_description", object.slug_path)).blank?
+        Multilingual::Translation.get("category_description", object.slug_path)[scope.current_user.locale.to_sym] || object.description_excerpt
+      else
+        object.description_excerpt
+      end
+    end
 
-      if !DiscourseTagging.validate_require_language_tag(
+    add_to_serializer(:site, :categories, false) do
+      object.categories.map do |c|
+        puts "slug de c : " + c[:slug]
+        if c[:slug] == "uncategorized"
+          c[:name] = I18n.t('uncategorized_category_name', locale: I18n.locale)
+        elsif SiteSetting.multilingual_enabled && !(c[:slug_path] && Multilingual::Translation.get("category_name", c[:slug_path])).blank?
+          if scope && scope.current_user && scope.current_user.locale
+            tmp_locale = scope.current_user.locale
+          else
+            tmp_locale = I18n.locale
+          end
+          c[:name] = Multilingual::Translation.get("category_name", c[:slug_path])[tmp_locale.to_sym] || c[:name]
+        end
+        c.to_h
+      end
+    end
+
+    add_to_serializer(:basic_category, :include_name_translations?) { name_translations.present? }
+
+    add_to_serializer(:basic_category, :include_description_translations?) { description_translations.present? }
+
+    add_to_serializer(:tag_group, :content_language_group) do
+      content_language_group_enabled || content_language_group_disabled
+    end
+
+    add_to_serializer(:tag_group, :content_language_group_enabled) do
+      object.id == Multilingual::ContentTag.enabled_group.id
+    end
+
+    add_to_serializer(:tag_group, :content_language_group_disabled) do
+      object.id == Multilingual::ContentTag.disabled_group.id
+    end
+
+    add_to_serializer(:tag_group, :name) do
+      content_language_group ?
+        I18n.t("multilingual.content_tag_group_name#{content_language_group_disabled ? "_disabled" : ""}") :
+        object.name
+    end
+
+    ## This is necessary due to the workaround for jquery ajax added in multilingual-initializer
+    on(:user_updated) do |user|
+      if Multilingual::ContentLanguage.enabled && user.custom_fields['content_languages'].blank?
+        user.custom_fields['content_languages'] = []
+        user.save_custom_fields(true)
+      end
+    end
+
+    on(:site_setting_changed) do |setting, old_val, new_val|
+      if setting.to_sym == :multilingual_content_languages_enabled &&
+        ActiveModel::Type::Boolean.new.cast(new_val)
+        Multilingual::ContentTag.enqueue_update_all
+      end
+    end
+
+    on(:before_create_topic) do |topic, creator|
+      if Multilingual::ContentLanguage.enabled
+        content_language_tags = [*creator.opts[:content_language_tags]]
+
+        if !DiscourseTagging.validate_require_language_tag(
           creator.guardian,
           topic,
           content_language_tags
         )
-        creator.rollback_from_errors!(topic)
-      end
+          creator.rollback_from_errors!(topic)
+        end
 
-      Multilingual::ContentTag.update_topic(topic, content_language_tags)
-    end
-  end
-
-  TopicQuery.add_custom_filter(:content_languages) do |result, query|
-    if Multilingual::ContentLanguage.topic_filtering_enabled
-      content_languages = query.user ?
-                          query.user.content_languages :
-                          [*query.options[:content_languages]]
-
-      if content_languages.present? && content_languages.any?
-        result = result.joins(:tags).where("tags.name in (?)", content_languages)
+        Multilingual::ContentTag.update_topic(topic, content_language_tags)
       end
     end
 
-    result
-  end
+    TopicQuery.add_custom_filter(:content_languages) do |result, query|
+      if Multilingual::ContentLanguage.topic_filtering_enabled
+        content_languages = query.user ?
+                              query.user.content_languages :
+                              [*query.options[:content_languages]]
 
-  tags_cb = ::PostRevisor.tracked_topic_fields[:tags]
+        if content_languages.present? && content_languages.any?
+          result = result.joins(:tags).where("tags.name in (?)", content_languages)
+        end
+      end
 
-  ::PostRevisor.tracked_topic_fields[:tags] = lambda do |tc, tags, fields|
-    if Multilingual::ContentLanguage.enabled
-      content_languages = tc.topic.content_languages
-      combined = (tags + content_languages).uniq
-      tc.check_result(DiscourseTagging.validate_require_language_tag(tc.guardian, tc.topic, combined))
-      tags_cb.call(tc, combined)
-    else
-      tags_cb.call(tc, tags)
+      result
+    end
+
+    tags_cb = ::PostRevisor.tracked_topic_fields[:tags]
+
+    ::PostRevisor.tracked_topic_fields[:tags] = lambda do |tc, tags, fields|
+      if Multilingual::ContentLanguage.enabled
+        content_languages = tc.topic.content_languages
+        combined = (tags + content_languages).uniq
+        tc.check_result(DiscourseTagging.validate_require_language_tag(tc.guardian, tc.topic, combined))
+        tags_cb.call(tc, combined)
+      else
+        tags_cb.call(tc, tags)
+      end
+    end
+
+    ::PostRevisor.track_topic_field(:content_language_tags) do |tc, content_language_tags, fields|
+      if Multilingual::ContentLanguage.enabled
+        content_language_tags = [*content_language_tags]
+        tc.check_result(DiscourseTagging.validate_require_language_tag(tc.guardian, tc.topic, content_language_tags))
+        tc.check_result(Multilingual::ContentTag.update_topic(tc.topic, content_language_tags))
+      end
     end
   end
-
-  ::PostRevisor.track_topic_field(:content_language_tags) do |tc, content_language_tags, fields|
-    if Multilingual::ContentLanguage.enabled
-      content_language_tags = [*content_language_tags]
-      tc.check_result(DiscourseTagging.validate_require_language_tag(tc.guardian, tc.topic, content_language_tags))
-      tc.check_result(Multilingual::ContentTag.update_topic(tc.topic, content_language_tags))
-    end
-  end
-end

--- a/plugin.rb
+++ b/plugin.rb
@@ -26,41 +26,41 @@ end
 end
 
 after_initialize do
-    %w[
-      ../lib/multilingual/multilingual.rb
-      ../lib/multilingual/cache.rb
-      ../lib/multilingual/language/content_tag.rb
-      ../lib/multilingual/language/exclusion.rb
-      ../lib/multilingual/language/custom.rb
-      ../lib/multilingual/language/content.rb
-      ../lib/multilingual/language/interface.rb
-      ../lib/multilingual/language.rb
-      ../lib/multilingual/translation/locale.rb
-      ../lib/multilingual/translation.rb
-      ../lib/multilingual/translator.rb
-      ../lib/multilingual/locale_loader.rb
-      ../jobs/update_content_language_tags.rb
-      ../config/routes.rb
-      ../app/models/multilingual/custom_translation.rb
-      ../app/serializers/multilingual/basic_language_serializer.rb
-      ../app/serializers/multilingual/language_serializer.rb
-      ../app/serializers/multilingual/custom_translation_serializer.rb
-      ../app/controllers/multilingual/admin_controller.rb
-      ../app/controllers/multilingual/admin_languages_controller.rb
-      ../app/controllers/multilingual/admin_translations_controller.rb
-      ../extensions/category_list.rb
-      ../extensions/discourse_tagging.rb
-      ../extensions/extra_locales_controller.rb
-      ../extensions/i18n.rb
-      ../extensions/js_locale_helper.rb
-      ../extensions/post.rb
-      ../extensions/tag_group.rb
-      ../extensions/topic_serializer.rb
-      ../extensions/application_controller.rb
-      ../extensions/tag.rb
-    ].each do |path|
-      load File.expand_path(path, __FILE__)
-    end
+  %w[
+    ../lib/multilingual/multilingual.rb
+    ../lib/multilingual/cache.rb
+    ../lib/multilingual/language/content_tag.rb
+    ../lib/multilingual/language/exclusion.rb
+    ../lib/multilingual/language/custom.rb
+    ../lib/multilingual/language/content.rb
+    ../lib/multilingual/language/interface.rb
+    ../lib/multilingual/language.rb
+    ../lib/multilingual/translation/locale.rb
+    ../lib/multilingual/translation.rb
+    ../lib/multilingual/translator.rb
+    ../lib/multilingual/locale_loader.rb
+    ../jobs/update_content_language_tags.rb
+    ../config/routes.rb
+    ../app/models/multilingual/custom_translation.rb
+    ../app/serializers/multilingual/basic_language_serializer.rb
+    ../app/serializers/multilingual/language_serializer.rb
+    ../app/serializers/multilingual/custom_translation_serializer.rb
+    ../app/controllers/multilingual/admin_controller.rb
+    ../app/controllers/multilingual/admin_languages_controller.rb
+    ../app/controllers/multilingual/admin_translations_controller.rb
+    ../extensions/category_list.rb
+    ../extensions/discourse_tagging.rb
+    ../extensions/extra_locales_controller.rb
+    ../extensions/i18n.rb
+    ../extensions/js_locale_helper.rb
+    ../extensions/post.rb
+    ../extensions/tag_group.rb
+    ../extensions/topic_serializer.rb
+    ../extensions/application_controller.rb
+    ../extensions/tag.rb
+  ].each do |path|
+    load File.expand_path(path, __FILE__)
+  end
 
   Multilingual.setup if SiteSetting.multilingual_enabled
 
@@ -92,266 +92,259 @@ after_initialize do
   add_to_class(:site, :interface_languages) { Multilingual::InterfaceLanguage.list }
   add_to_class(:site, :content_languages) { Multilingual::ContentLanguage.list }
 
-    add_to_class(:user, :effective_locale) do
-      if SiteSetting.allow_user_locale &&
-        self.locale.present? &&
-        Multilingual::InterfaceLanguage.enabled?(self.locale)
-        self.locale
-      else
-        SiteSetting.default_locale
-      end
+  add_to_class(:user, :effective_locale) do
+    if SiteSetting.allow_user_locale &&
+       self.locale.present? &&
+       Multilingual::InterfaceLanguage.enabled?(self.locale)
+      self.locale
+    else
+      SiteSetting.default_locale
     end
+  end
 
-    add_to_class(:user, :content_languages) do
-      content_languages = self.custom_fields['content_languages'] || []
-      [*content_languages].select { |l| Multilingual::ContentLanguage.enabled?(l) }
+  add_to_class(:user, :content_languages) do
+    content_languages = self.custom_fields['content_languages'] || []
+    [*content_languages].select { |l| Multilingual::ContentLanguage.enabled?(l) }
+  end
+
+  add_to_class(:topic, :content_languages) do
+    if custom_fields['content_languages']
+      [*custom_fields['content_languages']]
+    else
+      []
     end
+  end
 
-    add_to_class(:topic, :content_languages) do
-      if custom_fields['content_languages']
-        [*custom_fields['content_languages']]
-      else
-        []
-      end
-    end
+  add_to_class(:guardian, :topic_requires_language_tag?) do |topic|
+    !topic.private_message? &&
+    Multilingual::ContentLanguage.enabled &&
+    (SiteSetting.multilingual_require_content_language_tag === 'yes' ||
+    (!is_staff? && SiteSetting.multilingual_require_content_language_tag === 'non-staff'))
+  end
 
-    add_to_class(:guardian, :topic_requires_language_tag?) do |topic|
-      !topic.private_message? &&
-        Multilingual::ContentLanguage.enabled &&
-        (SiteSetting.multilingual_require_content_language_tag === 'yes' ||
-          (!is_staff? && SiteSetting.multilingual_require_content_language_tag === 'non-staff'))
-    end
+  add_to_class(:tag_groups_controller, :destroy_content_tags) do
+    guardian.is_admin?
+    Multilingual::ContentTag.destroy_all
+    render json: success_json
+  end
 
-    add_to_class(:tag_groups_controller, :destroy_content_tags) do
-      guardian.is_admin?
-      Multilingual::ContentTag.destroy_all
-      render json: success_json
-    end
+  add_to_class(:tag_groups_controller, :update_content_tags) do
+    guardian.is_admin?
+    Multilingual::ContentTag.update_all
+    render json: success_json
+  end
 
-    add_to_class(:tag_groups_controller, :update_content_tags) do
-      guardian.is_admin?
-      Multilingual::ContentTag.update_all
-      render json: success_json
-    end
-
-    add_class_method(:discourse_tagging, :validate_require_language_tag) do |guardian, topic, tag_names|
-      if guardian.topic_requires_language_tag?(topic) && (tag_names.blank? ||
-        !Tag.where(name: tag_names).where("id IN (
+  add_class_method(:discourse_tagging, :validate_require_language_tag) do |guardian, topic, tag_names|
+    if guardian.topic_requires_language_tag?(topic) && (tag_names.blank? ||
+       !Tag.where(name: tag_names).where("id IN (
           #{DiscourseTagging::TAG_GROUP_TAG_IDS_SQL}
           AND tg.name = '#{Multilingual::ContentTag::GROUP}'
         )").exists?)
 
-        topic.errors.add(:base, I18n.t("multilingual.content_language_tag_required"))
+      topic.errors.add(:base, I18n.t("multilingual.content_language_tag_required"))
 
-        false
-      else
-        true
-      end
+      false
+    else
+      true
     end
+  end
 
-    add_class_method(:locale_site_setting, :valid_value?) { |val| Multilingual::InterfaceLanguage.supported?(val) }
+  add_class_method(:locale_site_setting, :valid_value?) { |val| Multilingual::InterfaceLanguage.supported?(val) }
 
-    add_class_method(:locale_site_setting, :values) do
-      @values ||= supported_locales.reduce([]) do |result, locale|
-        if Multilingual::InterfaceLanguage.enabled?(locale)
-          lang = Multilingual::Language.all[locale] || Multilingual::Language.all[locale.split("_")[0]]
-          result.push(
-            name: lang ? lang['nativeName'] : locale,
-            value: locale
-          )
-        end
-        result
+  add_class_method(:locale_site_setting, :values) do
+    @values ||= supported_locales.reduce([]) do |result, locale|
+      if Multilingual::InterfaceLanguage.enabled?(locale)
+        lang = Multilingual::Language.all[locale] || Multilingual::Language.all[locale.split("_")[0]]
+        result.push(
+          name: lang ? lang['nativeName'] : locale,
+          value: locale
+        )
       end
+      result
     end
+  end
 
-    add_class_method(:js_locale_helper, :output_locale_tags) do |locale_str|
-      <<~JS
+  add_class_method(:js_locale_helper, :output_locale_tags) do |locale_str|
+    <<~JS
       I18n.tag_translations = #{Multilingual::Translation.get("tag").slice(locale_str.to_sym).to_json};
     JS
-    end
+  end
 
-    add_to_serializer(:user, :locale) do
-      Multilingual::InterfaceLanguage.enabled?(object.locale) ? object.locale : nil
-    end
+  add_to_serializer(:user, :locale) do
+    Multilingual::InterfaceLanguage.enabled?(object.locale) ? object.locale : nil
+  end
 
-    add_to_serializer(:site, :serialize_languages) do |languages = []|
-      ActiveModel::ArraySerializer.new(languages, each_serializer: Multilingual::BasicLanguageSerializer, root: false).as_json
-    end
+  add_to_serializer(:site, :serialize_languages) do |languages = []|
+    ActiveModel::ArraySerializer.new(languages, each_serializer: Multilingual::BasicLanguageSerializer, root: false).as_json
+  end
 
-    add_to_serializer(:site, :content_languages) { serialize_languages(object.content_languages) }
-    add_to_serializer(:site, :include_content_languages?) { Multilingual::ContentLanguage.enabled }
-    add_to_serializer(:site, :interface_languages) { serialize_languages(object.interface_languages) }
-    add_to_serializer(:topic_view, :content_language_tags) { Multilingual::ContentTag.filter(topic.tags).map(&:name) }
-    add_to_serializer(:topic_view, :include_content_language_tags?) { Multilingual::ContentLanguage.enabled }
-    add_to_serializer(:topic_list_item, :content_language_tags) { Multilingual::ContentTag.filter(topic.tags).map(&:name) }
-    add_to_serializer(:topic_list_item, :include_content_language_tags?) { Multilingual::ContentLanguage.enabled }
+  add_to_serializer(:site, :content_languages) { serialize_languages(object.content_languages) }
+  add_to_serializer(:site, :include_content_languages?) { Multilingual::ContentLanguage.enabled }
+  add_to_serializer(:site, :interface_languages) { serialize_languages(object.interface_languages) }
+  add_to_serializer(:topic_view, :content_language_tags) { Multilingual::ContentTag.filter(topic.tags).map(&:name) }
+  add_to_serializer(:topic_view, :include_content_language_tags?) { Multilingual::ContentLanguage.enabled }
+  add_to_serializer(:topic_list_item, :content_language_tags) { Multilingual::ContentTag.filter(topic.tags).map(&:name) }
+  add_to_serializer(:topic_list_item, :include_content_language_tags?) { Multilingual::ContentLanguage.enabled }
 
-    add_to_serializer(:current_user, :content_languages) do
-      if user_content_languages = object.content_languages
-        user_content_languages.map do |locale|
-          Multilingual::BasicLanguageSerializer.new(
-            Multilingual::Language.get(locale).first,
-            root: false
-          )
-        end
+  add_to_serializer(:current_user, :content_languages) do
+    if user_content_languages = object.content_languages
+      user_content_languages.map do |locale|
+        Multilingual::BasicLanguageSerializer.new(
+          Multilingual::Language.get(locale).first,
+          root: false
+        )
       end
     end
+  end
 
-    add_to_serializer(:basic_category, :slug_path, false) do
-      object.slug_path
+  add_to_serializer(:basic_category, :slug_path, false) do
+    object.slug_path
+  end
+
+  find_locale = -> (scope) {
+    if (scope && scope.current_user && scope.current_user.locale)
+      scope.current_user.locale
+    else
+      I18n.locale
     end
+  }
 
-    add_to_serializer(:basic_category, :name, false) do
-      if object.uncategorized?
-        puts "uncagecorized case"
-        I18n.t('uncategorized_category_name', locale: I18n.locale)
-      elsif !(object.slug_path && Multilingual::Translation.get("category_name", object.slug_path)).blank?
-        if (scope && scope.current_user && scope.current_user.locale)
-          tmp_locale = scope.current_user.locale
-        else
-          tmp_locale = I18n.locale
-        end
-        puts "tmp_locale = ", tmp_locale
-        puts "object.name = " + object.name
+  add_to_serializer(:basic_category, :name, false) do
+    if object.uncategorized?
+      I18n.t('uncategorized_category_name', locale: I18n.locale)
+    elsif !(object.slug_path && Multilingual::Translation.get("category_name", object.slug_path)).blank?
+      Multilingual::Translation.get("category_name", object.slug_path)[find_locale.call(scope).to_sym] || object.name
+    else
+      object.name
+    end
+  end
 
-        Multilingual::Translation.get("category_name", object.slug_path)[tmp_locale.to_sym] || object.name
-      else
-        object.name
+  add_to_serializer(:basic_category, :description_text, false) do
+    if object.uncategorized?
+      I18n.t('category.uncategorized_description', locale: I18n.locale)
+    elsif !(object.slug_path && Multilingual::Translation.get("category_description", object.slug_path)).blank?
+      Multilingual::Translation.get("category_description", object.slug_path)[find_locale.call(scope).to_sym] || object.description_text
+    else
+      object.description_text
+    end
+  end
+
+  add_to_serializer(:basic_category, :description, false) do
+    if object.uncategorized?
+      I18n.t('category.uncategorized_description', locale: I18n.locale)
+    elsif !(object.slug_path && Multilingual::Translation.get("category_description", object.slug_path)).blank?
+      Multilingual::Translation.get("category_description", object.slug_path)[find_locale.call(scope).to_sym] || object.description
+    else
+      object.description
+    end
+  end
+
+  add_to_serializer(:basic_category, :description_excerpt, false) do
+    if object.uncategorized?
+      I18n.t('category.uncategorized_description', locale: I18n.locale)
+    elsif !(object.slug_path && Multilingual::Translation.get("category_description", object.slug_path)).blank?
+      Multilingual::Translation.get("category_description", object.slug_path)[find_locale.call(scope).to_sym] || object.description_excerpt
+    else
+      object.description_excerpt
+    end
+  end
+
+  add_to_serializer(:site, :categories, false) do
+    object.categories.map do |c|
+      if c[:slug] == "uncategorized"
+        c[:name] = I18n.t('uncategorized_category_name', locale: I18n.locale)
+      elsif SiteSetting.multilingual_enabled && !(c[:slug_path] && Multilingual::Translation.get("category_name", c[:slug_path])).blank?
+        c[:name] = Multilingual::Translation.get("category_name", c[:slug_path])[find_locale.call(scope).to_sym] || c[:name]
       end
+      c.to_h
     end
+  end
 
-    add_to_serializer(:basic_category, :description_text, false) do
-      if object.uncategorized?
-        I18n.t('category.uncategorized_description', locale: SiteSetting.default_locale)
-      elsif !(scope && scope.current_user && scope.current_user.locale && object.slug_path && Multilingual::Translation.get("category_description", object.slug_path)).blank?
-        Multilingual::Translation.get("category_description", object.slug_path)[scope.current_user.locale.to_sym] || object.description_text
-      else
-        object.description_text
-      end
+  add_to_serializer(:basic_category, :include_name_translations?) { name_translations.present? }
+
+  add_to_serializer(:basic_category, :include_description_translations?) { description_translations.present? }
+
+  add_to_serializer(:tag_group, :content_language_group) do
+    content_language_group_enabled || content_language_group_disabled
+  end
+
+  add_to_serializer(:tag_group, :content_language_group_enabled) do
+    object.id == Multilingual::ContentTag.enabled_group.id
+  end
+
+  add_to_serializer(:tag_group, :content_language_group_disabled) do
+    object.id == Multilingual::ContentTag.disabled_group.id
+  end
+
+  add_to_serializer(:tag_group, :name) do
+    content_language_group ?
+    I18n.t("multilingual.content_tag_group_name#{content_language_group_disabled ? "_disabled" : ""}") :
+    object.name
+  end
+
+  ## This is necessary due to the workaround for jquery ajax added in multilingual-initializer
+  on(:user_updated) do |user|
+    if Multilingual::ContentLanguage.enabled && user.custom_fields['content_languages'].blank?
+      user.custom_fields['content_languages'] = []
+      user.save_custom_fields(true)
     end
+  end
 
-    add_to_serializer(:basic_category, :description, false) do
-      if object.uncategorized?
-        I18n.t('category.uncategorized_description', locale: SiteSetting.default_locale)
-      elsif !(scope && scope.current_user && scope.current_user.locale && object.slug_path && Multilingual::Translation.get("category_description", object.slug_path)).blank?
-        Multilingual::Translation.get("category_description", object.slug_path)[scope.current_user.locale.to_sym] || object.description
-      else
-        object.description
-      end
+  on(:site_setting_changed) do |setting, old_val, new_val|
+    if setting.to_sym == :multilingual_content_languages_enabled &&
+       ActiveModel::Type::Boolean.new.cast(new_val)
+      Multilingual::ContentTag.enqueue_update_all
     end
+  end
 
-    add_to_serializer(:basic_category, :description_excerpt, false) do
-      if object.uncategorized?
-        I18n.t('category.uncategorized_description', locale: SiteSetting.default_locale)
-      elsif !(scope && scope.current_user && scope.current_user.locale && object.slug_path && Multilingual::Translation.get("category_description", object.slug_path)).blank?
-        Multilingual::Translation.get("category_description", object.slug_path)[scope.current_user.locale.to_sym] || object.description_excerpt
-      else
-        object.description_excerpt
-      end
-    end
+  on(:before_create_topic) do |topic, creator|
+    if Multilingual::ContentLanguage.enabled
+      content_language_tags = [*creator.opts[:content_language_tags]]
 
-    add_to_serializer(:site, :categories, false) do
-      object.categories.map do |c|
-        puts "slug de c : " + c[:slug]
-        if c[:slug] == "uncategorized"
-          c[:name] = I18n.t('uncategorized_category_name', locale: I18n.locale)
-        elsif SiteSetting.multilingual_enabled && !(c[:slug_path] && Multilingual::Translation.get("category_name", c[:slug_path])).blank?
-          if scope && scope.current_user && scope.current_user.locale
-            tmp_locale = scope.current_user.locale
-          else
-            tmp_locale = I18n.locale
-          end
-          c[:name] = Multilingual::Translation.get("category_name", c[:slug_path])[tmp_locale.to_sym] || c[:name]
-        end
-        c.to_h
-      end
-    end
-
-    add_to_serializer(:basic_category, :include_name_translations?) { name_translations.present? }
-
-    add_to_serializer(:basic_category, :include_description_translations?) { description_translations.present? }
-
-    add_to_serializer(:tag_group, :content_language_group) do
-      content_language_group_enabled || content_language_group_disabled
-    end
-
-    add_to_serializer(:tag_group, :content_language_group_enabled) do
-      object.id == Multilingual::ContentTag.enabled_group.id
-    end
-
-    add_to_serializer(:tag_group, :content_language_group_disabled) do
-      object.id == Multilingual::ContentTag.disabled_group.id
-    end
-
-    add_to_serializer(:tag_group, :name) do
-      content_language_group ?
-        I18n.t("multilingual.content_tag_group_name#{content_language_group_disabled ? "_disabled" : ""}") :
-        object.name
-    end
-
-    ## This is necessary due to the workaround for jquery ajax added in multilingual-initializer
-    on(:user_updated) do |user|
-      if Multilingual::ContentLanguage.enabled && user.custom_fields['content_languages'].blank?
-        user.custom_fields['content_languages'] = []
-        user.save_custom_fields(true)
-      end
-    end
-
-    on(:site_setting_changed) do |setting, old_val, new_val|
-      if setting.to_sym == :multilingual_content_languages_enabled &&
-        ActiveModel::Type::Boolean.new.cast(new_val)
-        Multilingual::ContentTag.enqueue_update_all
-      end
-    end
-
-    on(:before_create_topic) do |topic, creator|
-      if Multilingual::ContentLanguage.enabled
-        content_language_tags = [*creator.opts[:content_language_tags]]
-
-        if !DiscourseTagging.validate_require_language_tag(
+      if !DiscourseTagging.validate_require_language_tag(
           creator.guardian,
           topic,
           content_language_tags
         )
-          creator.rollback_from_errors!(topic)
-        end
-
-        Multilingual::ContentTag.update_topic(topic, content_language_tags)
-      end
-    end
-
-    TopicQuery.add_custom_filter(:content_languages) do |result, query|
-      if Multilingual::ContentLanguage.topic_filtering_enabled
-        content_languages = query.user ?
-                              query.user.content_languages :
-                              [*query.options[:content_languages]]
-
-        if content_languages.present? && content_languages.any?
-          result = result.joins(:tags).where("tags.name in (?)", content_languages)
-        end
+        creator.rollback_from_errors!(topic)
       end
 
-      result
-    end
-
-    tags_cb = ::PostRevisor.tracked_topic_fields[:tags]
-
-    ::PostRevisor.tracked_topic_fields[:tags] = lambda do |tc, tags, fields|
-      if Multilingual::ContentLanguage.enabled
-        content_languages = tc.topic.content_languages
-        combined = (tags + content_languages).uniq
-        tc.check_result(DiscourseTagging.validate_require_language_tag(tc.guardian, tc.topic, combined))
-        tags_cb.call(tc, combined)
-      else
-        tags_cb.call(tc, tags)
-      end
-    end
-
-    ::PostRevisor.track_topic_field(:content_language_tags) do |tc, content_language_tags, fields|
-      if Multilingual::ContentLanguage.enabled
-        content_language_tags = [*content_language_tags]
-        tc.check_result(DiscourseTagging.validate_require_language_tag(tc.guardian, tc.topic, content_language_tags))
-        tc.check_result(Multilingual::ContentTag.update_topic(tc.topic, content_language_tags))
-      end
+      Multilingual::ContentTag.update_topic(topic, content_language_tags)
     end
   end
+
+  TopicQuery.add_custom_filter(:content_languages) do |result, query|
+    if Multilingual::ContentLanguage.topic_filtering_enabled
+      content_languages = query.user ?
+                          query.user.content_languages :
+                          [*query.options[:content_languages]]
+
+      if content_languages.present? && content_languages.any?
+        result = result.joins(:tags).where("tags.name in (?)", content_languages)
+      end
+    end
+
+    result
+  end
+
+  tags_cb = ::PostRevisor.tracked_topic_fields[:tags]
+
+  ::PostRevisor.tracked_topic_fields[:tags] = lambda do |tc, tags, fields|
+    if Multilingual::ContentLanguage.enabled
+      content_languages = tc.topic.content_languages
+      combined = (tags + content_languages).uniq
+      tc.check_result(DiscourseTagging.validate_require_language_tag(tc.guardian, tc.topic, combined))
+      tags_cb.call(tc, combined)
+    else
+      tags_cb.call(tc, tags)
+    end
+  end
+
+  ::PostRevisor.track_topic_field(:content_language_tags) do |tc, content_language_tags, fields|
+    if Multilingual::ContentLanguage.enabled
+      content_language_tags = [*content_language_tags]
+      tc.check_result(DiscourseTagging.validate_require_language_tag(tc.guardian, tc.topic, content_language_tags))
+      tc.check_result(Multilingual::ContentTag.update_topic(tc.topic, content_language_tags))
+    end
+  end
+end

--- a/plugin.rb
+++ b/plugin.rb
@@ -206,13 +206,16 @@ after_initialize do
     if (scope && scope.current_user && scope.current_user.locale)
       scope.current_user.locale
     else
-      I18n.locale
+      I18n.locale_available?(I18n.locale) ? I18n.locale : SiteSetting.default_locale
     end
   }
 
   add_to_serializer(:basic_category, :name, respect_plugin_enabled: false) do
     if object.uncategorized?
-      I18n.t('uncategorized_category_name', locale: I18n.locale)
+      I18n.t(
+        'uncategorized_category_name',
+        locale: I18n.locale_available?(I18n.locale) ? I18n.locale : SiteSetting.default_locale
+      )
     elsif !(object.slug_path && Multilingual::Translation.get("category_name", object.slug_path)).blank?
       Multilingual::Translation.get("category_name", object.slug_path)[find_locale.call(scope).to_sym] || object.name
     else
@@ -222,7 +225,10 @@ after_initialize do
 
   add_to_serializer(:basic_category, :description_text, respect_plugin_enabled: false) do
     if object.uncategorized?
-      I18n.t('category.uncategorized_description', locale: I18n.locale)
+      I18n.t(
+        'category.uncategorized_description',
+        locale: I18n.locale_available?(I18n.locale) ? I18n.locale : SiteSetting.default_locale
+      )
     elsif !(object.slug_path && Multilingual::Translation.get("category_description", object.slug_path)).blank?
       Multilingual::Translation.get("category_description", object.slug_path)[find_locale.call(scope).to_sym] || object.description_text
     else
@@ -232,7 +238,10 @@ after_initialize do
 
   add_to_serializer(:basic_category, :description, respect_plugin_enabled: false) do
     if object.uncategorized?
-      I18n.t('category.uncategorized_description', locale: I18n.locale)
+      I18n.t(
+        'category.uncategorized_description',
+        locale: I18n.locale_available?(I18n.locale) ? I18n.locale : SiteSetting.default_locale
+      )
     elsif !(object.slug_path && Multilingual::Translation.get("category_description", object.slug_path)).blank?
       Multilingual::Translation.get("category_description", object.slug_path)[find_locale.call(scope).to_sym] || object.description
     else
@@ -242,7 +251,10 @@ after_initialize do
 
   add_to_serializer(:basic_category, :description_excerpt, respect_plugin_enabled: false) do
     if object.uncategorized?
-      I18n.t('category.uncategorized_description', locale: I18n.locale)
+      I18n.t(
+        'category.uncategorized_description',
+        locale: I18n.locale_available?(I18n.locale) ? I18n.locale : SiteSetting.default_locale
+      )
     elsif !(object.slug_path && Multilingual::Translation.get("category_description", object.slug_path)).blank?
       Multilingual::Translation.get("category_description", object.slug_path)[find_locale.call(scope).to_sym] || object.description_excerpt
     else
@@ -253,7 +265,10 @@ after_initialize do
   add_to_serializer(:site, :categories, respect_plugin_enabled: false) do
     object.categories.map do |c|
       if c[:slug] == "uncategorized"
-        c[:name] = I18n.t('uncategorized_category_name', locale: I18n.locale)
+        c[:name] = I18n.t(
+          'uncategorized_category_name',
+          locale: I18n.locale_available?(I18n.locale) ? I18n.locale : SiteSetting.default_locale
+        )
       elsif SiteSetting.multilingual_enabled && !(c[:slug_path] && Multilingual::Translation.get("category_name", c[:slug_path])).blank?
         c[:name] = Multilingual::Translation.get("category_name", c[:slug_path])[find_locale.call(scope).to_sym] || c[:name]
       end


### PR DESCRIPTION
**Note: Currently, this PR doesn't fix a specific case that I'll explain later - it's still a relative improvement but might need some tweaking!**

# Base situation

On a forum me and my company are hosting, we're currently using this plugin to show both French and German users the translated names and descriptions of the categories, with the custom translation feature!

Unfortunately, we've noticed that for logged off users only see the site's default locale version of the translation, which creates a discrepancy between the base site and the categories, that the plugin should arrange :(

For reference, here are some screenshots - these are all coming from a local installation of Discouse running on Ubuntu 22.04 with English as the default locale:  

* Base version, while logged on/off
![en_logged_on_off_pre_fix](https://github.com/paviliondev/discourse-multilingual/assets/72192278/436926d4-b9c3-45fc-b75e-851f984cad21)

* Custom french translation, logged on
![fr_logged_on](https://github.com/paviliondev/discourse-multilingual/assets/72192278/f3d0602c-3db3-43a6-ae19-a2ebb612e40b)

* Logged off user with fr locale in browser, pre-fix
![fr_logged_off_pre_fix](https://github.com/paviliondev/discourse-multilingual/assets/72192278/29820b8c-d683-45b7-bf3d-fe62481eee3a)

As you can see, while the category and topic nouns are translated (__"Catégories"__ and __"Sujets"__), the categories names, descriptions and subcategories are not translated and remain in the site's default locale, and this mismatch is what I aimed to fix - now, I present to you this fix!

# Fix

In the current production code, the locale is detected in the `plugin.rb` files, in the `add_to_serializer` relating to the custom translations of the category names, descriptions, and subcategories.
However, the way it infers the used locale is by getting either the logged-on user's Interface language setting `scope.current_user.locale`, or the default locale of the site `SiteSetting.default_locale`. 

```rb
    if object.uncategorized?
      I18n.t('uncategorized_category_name', locale: SiteSetting.default_locale)
    elsif !(scope && scope.current_user && scope.current_user.locale && object.slug_path && Multilingual::Translation.get("category_name", object.slug_path)).blank?
      Multilingual::Translation.get("category_name", object.slug_path)[scope.current_user.locale.to_sym] || object.name
    else
      object.name
    end
```
This is not ideal, as for a multilingual plugin, it would be right to assume that a given user's client wouldn't match the site's default locale, and it would be preferable to show them the translation that are in their language (if the translation exists).

As a fix, I've decided to use the `I18n.locale` variable - indeed, this variable is set by the site through cookies or HTTP requests (if the site allows so), and when the value is updated, it runs through the serializers to get the corresponding translation, or the base one if the translation is not available.

So, I've inserted this lambda that tests if a current user is logged on, or if the locale set by I18n is supported in the plugin (through the overridden `locale_available?` method)
```rb
  find_locale = -> (scope) {
    if (scope && scope.current_user && scope.current_user.locale)
      scope.current_user.locale
    else
      I18n.locale_available?(I18n.locale) ? I18n.locale : SiteSetting.default_locale
    end
  }
```

Then I've modified the corresponding `add_to_serializer` calls to use this lambda. For instance, here's the `add_to_serializer` call getting the translation for a main category's name : 
```rb
  add_to_serializer(:basic_category, :name, respect_plugin_enabled: false) do
    if object.uncategorized?
      I18n.t(
        'uncategorized_category_name',
        locale: I18n.locale_available?(I18n.locale) ? I18n.locale : SiteSetting.default_locale
      )
    elsif !(object.slug_path && Multilingual::Translation.get("category_name", object.slug_path)).blank?
      Multilingual::Translation.get("category_name", object.slug_path)[find_locale.call(scope).to_sym] || object.name
    else
      object.name
    end
  end
```

# Results of the fix 

With this implemented, the logged-on users are not affected - as for the logged-off users, here are the differences : 
* The custom translations of the name and description are displayed to users in their language (if the site allows header or cookies reading)
* The custom translations of the sub categories are only shown when a given category's `show_subcategory_list` is activated/true

* Base version (English) - unaffected
![en_logged_on_off_post_fix](https://github.com/paviliondev/discourse-multilingual/assets/72192278/5aaf1a36-be97-4423-997f-a58e9dece0f9)

* Custom translation post fix (French) - `show_subcategory_list` off for `Test deux`
![fr_logged_off_post_fix_no_subcat](https://github.com/paviliondev/discourse-multilingual/assets/72192278/41a8f84c-94e7-4cac-8fc4-671ccb406574)

* Custom translation post fix (French) - `show_subcategory_list` on for `Test deux`
![fr_logged_off_post_fix_subcat_show](https://github.com/paviliondev/discourse-multilingual/assets/72192278/9eea5964-fe8a-4c68-a366-49eb1b4ec657)

As you can see, the fix is mostly functional, except for this specific case for subcategories when the option to show a list of subcategories in a main category is off. After testing, it would seem that this is the case because the site doesn't rerun/yield the serializer relating to the subcategories unless this option is on, so only the default names are shown (initiated when the instance is launched, with the default locale).
Sadly, I'm not well versed enough in either Ruby or the structure of the main discourse code as well as this plugin's - so, if maintainers on this repository wish to fix that specific case and then fuse this PR with the main code, I'd be very pleased :)