### PR TITLE
DEV: Update header icons for Glimmer Header

### DIFF
--- a/assets/javascripts/discourse/components/language-switcher-menu.gjs
+++ b/assets/javascripts/discourse/components/language-switcher-menu.gjs
@@ -1,0 +1,44 @@
+import Component from "@glimmer/component";
+import { fn } from "@ember/helper";
+import { on } from "@ember/modifier";
+import { action } from "@ember/object";
+import { service } from "@ember/service";
+import concatClass from "discourse/helpers/concat-class";
+import I18n from "discourse-i18n";
+import eq from "truth-helpers/helpers/eq";
+import { addParam, localeParam } from "../lib/multilingual-route";
+
+export default class LanguageSwitcherMenu extends Component {
+  @service site;
+
+  get currentLocale() {
+    return I18n.currentLocale();
+  }
+
+  @action
+  change(locale) {
+    addParam(localeParam, locale, { add_cookie: true, ctx: this });
+  }
+
+  <template>
+    <div class="language-switcher-menu">
+      <ul>
+        {{#each this.site.interface_languages as |l|}}
+          <li>
+            {{! template-lint-disable no-invalid-interactive }}
+            <a
+              class={{concatClass
+                "ls-language"
+                (if (eq l.locale this.currentLocale) "current")
+              }}
+              {{on "click" (fn this.change l.locale)}}
+              label={{l.name}}
+            >
+              {{l.name}}
+            </a>
+          </li>
+        {{/each}}
+      </ul>
+    </div>
+  </template>
+}

--- a/assets/javascripts/discourse/components/language-switcher.gjs
+++ b/assets/javascripts/discourse/components/language-switcher.gjs
@@ -1,0 +1,19 @@
+import Component from "@glimmer/component";
+import DMenu from "float-kit/components/d-menu";
+import i18n from "discourse-common/helpers/i18n";
+import LanguageSwitcherMenu from "./language-switcher-menu";
+
+export default class LanguageSwitcher extends Component {
+  <template>
+    <DMenu
+      title={{i18n "user.locale.title"}}
+      @icon="translate"
+      id="multilingual-language-switcher"
+      class="icon btn-flat"
+    >
+      <:content>
+        <LanguageSwitcherMenu />
+      </:content>
+    </DMenu>
+  </template>
+}

--- a/assets/javascripts/discourse/initializers/multilingual-initializer.js.es6
+++ b/assets/javascripts/discourse/initializers/multilingual-initializer.js.es6
@@ -15,7 +15,7 @@ import { iconHTML } from "discourse-common/lib/icon-library";
 import renderTag from "discourse/lib/render-tag";
 import { computed, set } from "@ember/object";
 import { scheduleOnce } from "@ember/runloop";
-import jQuery from "jquery";
+import LanguageSwitcher from "../components/language-switcher";
 
 export default {
   name: "multilingual",
@@ -38,7 +38,7 @@ export default {
       );
     }
 
-    withPluginApi("0.8.36", (api) => {
+    withPluginApi("1.28.0", (api) => {
       api.replaceTagRenderer(multilingualTagRenderer);
 
       discoveryParams.forEach((param) => {
@@ -76,7 +76,6 @@ export default {
               return this._super();
             }
 
-            // jQuery ajax removes empty arrays. This is a workaround
             let cl = this.model.custom_fields.content_languages;
             if (!cl || !cl.length) {
               this.set("model.custom_fields.content_languages", [""]);
@@ -194,35 +193,7 @@ export default {
         !currentUser &&
         siteSettings.multilingual_guest_language_switcher === "header"
       ) {
-        api.reopenWidget("header", {
-          defaultState() {
-            return jQuery.extend(this._super(...arguments), {
-              languageSwitcherMenuVisible: false,
-            });
-          },
-
-          toggleLangugeSwitcherMenu() {
-            this.state.languageSwitcherMenuVisible =
-              !this.state.languageSwitcherMenuVisible;
-          },
-        });
-
-        api.decorateWidget("header-icons:before", (helper) => {
-          return helper.attach("header-dropdown", {
-            title: "user.locale.title",
-            icon: "translate",
-            iconId: "language-switcher-menu-button",
-            action: "toggleLangugeSwitcherMenu",
-            active:
-              helper.widget.parentWidget.state.languageSwitcherMenuVisible,
-          });
-        });
-
-        api.addHeaderPanel(
-          "language-switcher-menu",
-          "languageSwitcherMenuVisible",
-          (attrs, state) => ({ attrs, state })
-        );
+        api.headerIcons.add("multilingual-language-switcher", LanguageSwitcher);
       }
 
       api.modifyClass("route:tag-groups-edit", {

--- a/assets/stylesheets/common/multilingual/language-switcher.scss
+++ b/assets/stylesheets/common/multilingual/language-switcher.scss
@@ -12,6 +12,7 @@
 
   &:hover {
     background-color: var(--tertiary-low) !important;
+    color: var(--primary);
   }
 
   &.current {
@@ -94,10 +95,7 @@ html.rtl {
 }
 
 .language-switcher-menu {
-  .panel-body-contents {
-    overflow-y: scroll;
-  }
-
+  padding: 0.4em;
   ul {
     list-style: none;
     margin: 0;
@@ -107,8 +105,13 @@ html.rtl {
 
     li {
       margin: 5px 0;
-      display: inline-block;
       width: 100%;
+      a {
+        display: block;
+      }
+      a:visited {
+        color: var(--primary);
+      }
     }
   }
 }


### PR DESCRIPTION
- Utilize `headerIcons` plugin API
- Utilize float kit's `DMenu` for the `language-switcher` to render dropdown content

<img width="1008" alt="Screenshot 2024-03-08 at 8 55 05 AM" src="https://github.com/discourse/discourse-multilingual/assets/50783505/a0646ebc-b73a-453d-ab44-951ca4138b08">

