### PR TITLE
FIX: broken dropdown following core change

### DIFF
--- a/assets/javascripts/select-kit/components/content-languages-dropdown.js.es6
+++ b/assets/javascripts/select-kit/components/content-languages-dropdown.js.es6
@@ -19,6 +19,8 @@ export default DropdownSelectBox.extend({
   },
 
   didInsertElement() {
+    this._super(...arguments);
+
     if (!this.currentUser) {
       this.selectKit.options.set("filterable", true);
     }


### PR DESCRIPTION
Core added a new event registration/deregistration in https://github.com/discourse/discourse/pull/26345 

That caused a regression in this plugin, because `didInsertElement` wasn't calling `_super`, so when the event reregistration was due (during `willDestroyElement`) an error would be raised: 

```
Assertion Failed: You attempted to remove a function listener which did not exist on the instance, which means you may have attempted to remove it before it was added.
```

This showed up in JS tests as well as when clicking "Set content languages" in the dropdown. 